### PR TITLE
Return integers for memory values

### DIFF
--- a/postgresql_tune.py
+++ b/postgresql_tune.py
@@ -143,7 +143,7 @@ def format_size(size):
         value = size
         unit = 'kB'
 
-    return '{}{}'.format(value, unit)
+    return '{}{}'.format(int(value), unit)
 
 
 def get_pgtune_config(module):


### PR DESCRIPTION
Postgres fails to start if the memory values are float. Calling int() when formatting the value fixes the problem.